### PR TITLE
Fix URL properties in version files

### DIFF
--- a/GameData/SpaceY/SpaceYLifters/SpaceYLifters.version
+++ b/GameData/SpaceY/SpaceYLifters/SpaceYLifters.version
@@ -1,6 +1,6 @@
 {
 	"NAME"           : "SpaceY Lifters (SYL) by NecroBones",
-	"URL"		     : "https://raw.githubusercontent.com/zer0Kerbal/SpaceY-Lifters/master/SpaceY-Lifters.version",
+	"URL"		     : "https://raw.githubusercontent.com/zer0Kerbal/SpaceYLifters/master/SpaceYLifters.version",
 	"DOWNLOAD"	     : "https://github.com/zer0Kerbal/SpaceY-Lifters/releases/latest",
 	"CHANGE_LOG_URL" : "https://raw.githubusercontent.com/zer0Kerbal/SpaceY-Lifters/master/changelog.md",
 	"GITHUB" :

--- a/SpaceYLifters.version
+++ b/SpaceYLifters.version
@@ -1,6 +1,6 @@
 {
 	"NAME"           : "SpaceY Lifters (SYL) by NecroBones",
-	"URL"		     : "https://raw.githubusercontent.com/zer0Kerbal/SpaceY-Lifters/master/SpaceY-Lifters.version",
+	"URL"		     : "https://raw.githubusercontent.com/zer0Kerbal/SpaceYLifters/master/SpaceYLifters.version",
 	"DOWNLOAD"	     : "https://github.com/zer0Kerbal/SpaceY-Lifters/releases/latest",
 	"CHANGE_LOG_URL" : "https://raw.githubusercontent.com/zer0Kerbal/SpaceY-Lifters/master/changelog.md",
 	"GITHUB" :


### PR DESCRIPTION
The URL properties of the version files contain extra `-` characters, breaking the links, which will deprive KSP-AVC users of new-update notifications and prevents maintainers from making post-release updates to compatibility.

This pull request fixes the links.

Noticed while working on KSP-CKAN/NetKAN#9557.
